### PR TITLE
Add README with folder icon and use favourite.webp as favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+<p align="center">
+  <img src="favourite.webp" alt="Folder icon" width="100">
+</p>
+
+# Whisper WebUI
+
+一个使用 Groq Whisper API 将音频转为 SRT 字幕的简单网页工具。
+
+## 使用
+
+1. 打开 `index.html`。
+2. 上传或拖拽音频文件。
+3. 等待生成并下载 `srt` 文件。
+
+## 许可证
+
+MIT
+

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Groq Whisper API 转 SRT 工具</title>
+    <link rel="icon" type="image/webp" href="favourite.webp">
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-8WF6G1CWV7"></script>


### PR DESCRIPTION
## Summary
- add README with folder icon and basic usage instructions
- link favourite.webp as the site's favicon and remove old ico file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f3ae1b948321a29a65877d5d891d